### PR TITLE
Remove unused media constants

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -1,10 +1,6 @@
 import Constants, { ExecutionEnvironment } from "expo-constants";
 
-import {
-  MediaListStatus,
-  MediaListSort,
-  MediaStatus,
-} from "yep/graphql/generated";
+import { MediaListStatus } from "yep/graphql/generated";
 
 // AniList Client IDs and their redirect URIs based on https://docs.expo.dev/guides/authentication/#redirect-uri-patterns
 enum AniListClientID {
@@ -35,19 +31,4 @@ export const MediaListStatusWithLabel: {
   { value: MediaListStatus.Planning },
   { value: MediaListStatus.Dropped },
   { value: MediaListStatus.Completed },
-];
-
-export const MediaStatusWithLabel: {
-  value: MediaStatus;
-}[] = [
-  { value: MediaStatus.Finished },
-  { value: MediaStatus.Releasing },
-  { value: MediaStatus.NotYetReleased },
-  { value: MediaStatus.Cancelled },
-];
-
-export const Sorts: { value: MediaListSort }[] = [
-  { value: MediaListSort.UpdatedTimeDesc },
-  { value: MediaListSort.ScoreDesc },
-  { value: MediaListSort.Score },
 ];


### PR DESCRIPTION
## Summary
- remove unused MediaStatusWithLabel and Sorts exports
- drop now-unused generated enum imports

## Check
- bunx tsc --noEmit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused constants `MediaStatusWithLabel` and `Sorts`, and eliminated unused GraphQL enum imports to reduce dead code and simplify `constants.ts`. No functional changes.

<sup>Written for commit 7a3e79b4b146c222d0269f8cd1c6c8aac7a5f312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/FiberJW/goodweebs/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

